### PR TITLE
Handle intent updates via MethodChannel

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,18 +1,41 @@
 import 'package:Discography/home_page.dart';
 import 'package:Discography/listdossierpage.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 void main() {
   runApp(MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  static const _channel = MethodChannel('fr.discography.voice/intent');
+  final GlobalKey<NavigatorState> _navKey = GlobalKey<NavigatorState>();
+
+  @override
+  void initState() {
+    super.initState();
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'navigate') {
+        final route = call.arguments as String?;
+        if (route != null) {
+          _navKey.currentState?.pushNamed(route);
+        }
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Etude',
+      navigatorKey: _navKey,
       initialRoute: '/',
       onGenerateRoute: (settings) {
         if (settings.name?.startsWith('/listdossier') ?? false) {


### PR DESCRIPTION
## Summary
- factor out intent route logic in `MainActivity`
- send route updates to Flutter using a MethodChannel
- listen on that channel in Flutter and navigate accordingly

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684831e817588323b8606a58cffc98b4