### PR TITLE
Enable deep link routing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:Discography/home_page.dart';
 import 'package:Discography/listdossierpage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'dart:ui';
 
 void main() {
   runApp(MyApp());
@@ -36,7 +37,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Etude',
       navigatorKey: _navKey,
-      initialRoute: '/',
+      initialRoute: WidgetsBinding.instance.platformDispatcher.defaultRouteName,
       onGenerateRoute: (settings) {
         if (settings.name?.startsWith('/listdossier') ?? false) {
           final uri = Uri.parse(settings.name!);


### PR DESCRIPTION
## Summary
- import `dart:ui` and use platform dispatcher default route

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848414029308323b607fb7bebb08ce0